### PR TITLE
Use local storage

### DIFF
--- a/options.html
+++ b/options.html
@@ -13,16 +13,21 @@
             <div class="panel">
                 <div class="panel-body">
                     <form id="options-form">
-                        <h1>Options</h1>
+                        <h1 class="page-header">Options</h1>
                         <div class="form-group">
                             <label for="url">
                                 Github Enterprise URL
                             </label>
                             <input id="url" type="url" class="form-control">
                         </div>
-                        <div class="form-group">
+                        <div class="checkbox">
                             <label>
-                                Allow backtick to switch tabs on pull requests? <input id="tabSwitchingEnabled" type="checkbox">
+                                <input id="saveCollapsedDiffs" type="checkbox">Save collapsed diffs
+                            </label>
+                        </div>
+                        <div class="checkbox">
+                            <label>
+                                <input id="tabSwitchingEnabled" type="checkbox">Allow backtick to switch tabs on pull requests
                             </label>
                         </div>
                         <button class="btn btn-primary" id="save">Save</button>

--- a/options.js
+++ b/options.js
@@ -36,6 +36,7 @@
   $(document).ready(function () {
     loadItemsFromChromeStorage({
       url: '',
+      saveCollapsedDiffs: true,
       tabSwitchingEnabled: false
       // Add new items here to get them loaded and their values put in the form.
     }, setFormValues);
@@ -45,11 +46,13 @@
 
       var $form = $(e.currentTarget);
       var url = $form.find('#url').val();
+      var saveCollapsedDiffs = $form.find('#saveCollapsedDiffs').prop('checked');
       var tabSwitchingEnabled = $form.find('#tabSwitchingEnabled').prop('checked');
 
       saveOptionsToChromeStorage({
         'url': url,
-        'tabSwitchingEnabled': tabSwitchingEnabled,
+        'saveCollapsedDiffs': saveCollapsedDiffs,
+        'tabSwitchingEnabled': tabSwitchingEnabled
       }, function () {
           var status = $('#status');
           status.text('Options saved.');

--- a/popup.js
+++ b/popup.js
@@ -73,13 +73,13 @@ chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
                             "Collapse": {
                                 "label": "Collapse Diff",
                                 "action": function (obj) {
-                                    port.postMessage({collapse: $node.id});
+                                    port.postMessage({collapse: '^' + $node.id});
                                 }
                             },
                             "Expand": {
                                 "label": "Expand Diff",
                                 "action": function (obj) {
-                                    port.postMessage({expand: $node.id});
+                                    port.postMessage({expand: '^' + $node.id});
                                 }
                             },
                             "Goto": {

--- a/popup.js
+++ b/popup.js
@@ -57,7 +57,6 @@ chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
     chrome.tabs.sendMessage(tabs[0].id, {getPaths: true}, function(response) {
         if (response.paths) {
             var nodes = convertPathsToNodes(response.paths);
-            console.log(nodes);
             $('#tree').jstree({
                 'core' : {
                     'data' : nodes,
@@ -74,13 +73,13 @@ chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
                             "Collapse": {
                                 "label": "Collapse Diff",
                                 "action": function (obj) {
-                                    port.postMessage({collapse: '^' + $node.id});
+                                    port.postMessage({collapse: $node.id});
                                 }
                             },
                             "Expand": {
                                 "label": "Expand Diff",
                                 "action": function (obj) {
-                                    port.postMessage({expand: '^' + $node.id});
+                                    port.postMessage({expand: $node.id});
                                 }
                             },
                             "Goto": {

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -64,9 +64,10 @@ function moveToPreviousTab($pullRequestTabs, selectedTabIndex) {
     $pullRequestTabs[selectedTabIndex].click();
 }
 
-function hideDiffs() {
-    var $a = $('a[name^=diff-]').each(function(index, item) {
+function initDiffs() {
+    $('a[name^=diff-]').each(function(index, item) {
         var id = $(item).attr('name');
+
         if (localStorage.getItem(id) === 'hide') {
             toggleDiff(id, 0, 'hide');
         }
@@ -113,7 +114,7 @@ chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
         var injectHtmlIfNecessary = function () {
             if (!htmlIsInjected()) {
                 injectHtml();
-                hideDiffs();
+                initDiffs();
             }
             setTimeout(injectHtmlIfNecessary, 1000);
         };

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -39,11 +39,11 @@ function getDiffSpans(path) {
 function getIds(path) {
     var $spans = getDiffSpans(path).closest('[id^=diff-]');
     var $as = $spans.prev('a[name^=diff-]');
-    var ids = $as.map(function(index, a) {
+    var $ids = $as.map(function(index, a) {
         return $(a).attr('name');
     });
 
-    return ids;
+    return $ids;
 }
 
 function getId(path) {
@@ -54,19 +54,11 @@ function getId(path) {
     return id;
 }
 
-function collapseDiffs(path) {
-    var ids = getIds(path);
+function toggleDiffs(path, display) {
+    var $ids = getIds(path);
 
-    ids.each(function(index, id) {
-        toggleDiff(id, 200, 'hide');
-    });
-}
-
-function expandDiffs(path) {
-    var ids = getIds(path);
-
-    ids.each(function(index, id) {
-        toggleDiff(id, 200, 'show');
+    $ids.each(function(index, id) {
+        toggleDiff(id, 200, display);
     });
 }
 
@@ -186,10 +178,10 @@ chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
 
             port.onMessage.addListener(function (msg) {
                 if (msg.collapse !== undefined) {
-                    collapseDiffs(msg.collapse);
+                    toggleDiffs(msg.collapse, 'hide');
                 }
                 if (msg.expand !== undefined) {
-                    expandDiffs(msg.expand);
+                    toggleDiffs(msg.expand, 'show');
                 }
                 if (msg.goto !== undefined) {
                     getDiffSpans(msg.goto)[0].scrollIntoViewIfNeeded();

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -64,6 +64,39 @@ function moveToPreviousTab($pullRequestTabs, selectedTabIndex) {
     $pullRequestTabs[selectedTabIndex].click();
 }
 
+function toggleDiff(id, duration, display) {
+    var $a = $('a[name^=' + id + ']');
+
+    duration = duration ? duration : 200;
+
+    if (display != 'show' && display != 'hide') {
+        display = localStorage.getItem(id) === 'hide' ? 'show' : 'hide';
+    }
+
+    if ($a) {
+        var $span = $a.next('div[id^=diff-]');
+        var $data = $span.children('.data, .image');
+        var $bottom = $span.children('.bottom-collapse');
+
+        if (display === 'show') {
+            $data.slideDown(duration);
+            $bottom.show();
+        } else {
+            $data.slideUp(duration);
+            $bottom.hide();
+        }
+
+        return localStorage.setItem(id, display);
+    }
+    return false;
+}
+
+function clickDiff(event) {
+    var id = $(this).closest('[id^=diff-]').prev('a[name^=diff-]').attr('name');
+
+    return toggleDiff(id);
+}
+
 chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
     if (items.url == window.location.origin ||
         "https://github.com" === window.location.origin) {
@@ -78,16 +111,7 @@ chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
 
         var $body = $('body');
 
-        $body.on('click', '.user-select-contain, .js-selectable-text, .bottom-collapse', function (e) {
-            var span = $(this).closest('[id^=diff-]');
-            span.children('.data, .image').slideToggle(200);
-            if ($(e.target).hasClass('bottom-collapse')) {
-                $(this).closest('div.bottom-collapse').toggle();
-            } else {
-                span.children('div.bottom-collapse').toggle();
-            }
-            span.children('.meta')[0].scrollIntoViewIfNeeded();
-        });
+        $body.on('click', '.user-select-contain, .js-selectable-text, .bottom-collapse', clickDiff);
 
         $body.on('click', '.js-collapse-additions', collapseAdditions);
 

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -78,6 +78,14 @@ function moveToPreviousTab($pullRequestTabs, selectedTabIndex) {
     $pullRequestTabs[selectedTabIndex].click();
 }
 
+function getIdFromPath(path) {
+    var $span = $('span[title="' + path + '"]').closest('[id^=diff-]');
+    var $a = $span.prev('a[name^=diff-]');
+    var id = $a.attr('name');
+
+    return id;
+}
+
 function initDiffs() {
     $('a[name^=diff-]').each(function(index, item) {
         var id = $(item).attr('name');
@@ -115,10 +123,19 @@ function toggleDiff(id, duration, display) {
     return false;
 }
 
-function clickDiff(event) {
-    var id = $(this).closest('[id^=diff-]').prev('a[name^=diff-]').attr('name');
+function clickTitle(event) {
+    var path = $(this).attr('title');
+    var id = getIdFromPath(path);
 
     return toggleDiff(id);
+}
+
+function clickCollapse(event) {
+    var $span = $(this).prevAll('.file-header');
+    var path = $span.attr('data-path');
+    var id = getIdFromPath(path);
+
+    return toggleDiff(id, '200', 'hide');
 }
 
 chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
@@ -136,7 +153,9 @@ chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
 
         var $body = $('body');
 
-        $body.on('click', '.user-select-contain, .js-selectable-text, .bottom-collapse', clickDiff);
+        $body.on('click', '.user-select-contain, .js-selectable-text', clickTitle);
+
+        $body.on('click', '.bottom-collapse', clickCollapse);
 
         $body.on('click', '.js-collapse-additions', collapseAdditions);
 

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -93,8 +93,8 @@ function toggleDiff(id, duration, display) {
 
     duration = duration ? duration : 200;
 
-    if (display != 'show' && display != 'hide') {
-        display = localStorage.getItem(id) === 'hide' ? 'show' : 'hide';
+    if (display !== 'show' && display !== 'hide') {
+        display = (localStorage.getItem(id) === 'hide') ? 'show' : 'hide';
     }
 
     if ($a) {

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -64,6 +64,15 @@ function moveToPreviousTab($pullRequestTabs, selectedTabIndex) {
     $pullRequestTabs[selectedTabIndex].click();
 }
 
+function hideDiffs() {
+    var $a = $('a[name^=diff-]').each(function(index, item) {
+        var id = $(item).attr('name');
+        if (localStorage.getItem(id) === 'hide') {
+            toggleDiff(id, 0, 'hide');
+        }
+    });
+}
+
 function toggleDiff(id, duration, display) {
     var $a = $('a[name^=' + id + ']');
 
@@ -104,6 +113,7 @@ chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
         var injectHtmlIfNecessary = function () {
             if (!htmlIsInjected()) {
                 injectHtml();
+                hideDiffs();
             }
             setTimeout(injectHtmlIfNecessary, 1000);
         };

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -46,6 +46,14 @@ function getIds(path) {
     return ids;
 }
 
+function getId(path) {
+    var $span = $('span[title="' + path + '"]').closest('[id^=diff-]');
+    var $a = $span.prev('a[name^=diff-]');
+    var id = $a.attr('name');
+
+    return id;
+}
+
 function collapseDiffs(path) {
     var ids = getIds(path);
 
@@ -76,14 +84,6 @@ function moveToPreviousTab($pullRequestTabs, selectedTabIndex) {
         selectedTabIndex = $pullRequestTabs.length - 1;
     }
     $pullRequestTabs[selectedTabIndex].click();
-}
-
-function getIdFromPath(path) {
-    var $span = $('span[title="' + path + '"]').closest('[id^=diff-]');
-    var $a = $span.prev('a[name^=diff-]');
-    var id = $a.attr('name');
-
-    return id;
 }
 
 function initDiffs() {
@@ -125,7 +125,7 @@ function toggleDiff(id, duration, display) {
 
 function clickTitle(event) {
     var path = $(this).attr('title');
-    var id = getIdFromPath(path);
+    var id = getId(path);
 
     return toggleDiff(id);
 }
@@ -133,7 +133,7 @@ function clickTitle(event) {
 function clickCollapse(event) {
     var $span = $(this).prevAll('.file-header');
     var path = $span.attr('data-path');
-    var id = getIdFromPath(path);
+    var id = getId(path);
 
     return toggleDiff(id, '200', 'hide');
 }

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -36,16 +36,30 @@ function getDiffSpans(path) {
     });
 }
 
+function getIds(path) {
+    var $spans = getDiffSpans(path).closest('[id^=diff-]');
+    var $as = $spans.prev('a[name^=diff-]');
+    var ids = $as.map(function(index, a) {
+        return $(a).attr('name');
+    });
+
+    return ids;
+}
+
 function collapseDiffs(path) {
-    var spans = getDiffSpans(path).closest('[id^=diff-]');
-    spans.children('.data, .image').slideUp(200);
-    spans.children('div.bottom-collapse').hide();
+    var ids = getIds(path);
+
+    ids.each(function(index, id) {
+        toggleDiff(id, 200, 'hide');
+    });
 }
 
 function expandDiffs(path) {
-    var spans = getDiffSpans(path).closest('[id^=diff-]');
-    spans.children('.data, .image').slideDown(200);
-    spans.children('div.bottom-collapse').show();
+    var ids = getIds(path);
+
+    ids.each(function(index, id) {
+        toggleDiff(id, 200, 'show');
+    });
 }
 
 function moveToNextTab($pullRequestTabs, selectedTabIndex) {

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -54,6 +54,33 @@ function getId(path) {
     return id;
 }
 
+function toggleDiff(id, duration, display) {
+    var $a = $('a[name^=' + id + ']');
+
+    duration = !isNaN(duration) ? duration : 200;
+
+    if (display !== 'expand' && display !== 'collapse') {
+        display = (localStorage.getItem(id) === 'collapse') ? 'expand' : 'collapse';
+    }
+
+    if ($a) {
+        var $span = $a.next('div[id^=diff-]');
+        var $data = $span.children('.data, .image');
+        var $bottom = $span.children('.bottom-collapse');
+
+        if (display === 'expand') {
+            $data.slideDown(duration);
+            $bottom.show();
+            return localStorage.removeItem(id);
+        }
+
+        $data.slideUp(duration);
+        $bottom.hide();
+        return localStorage.setItem(id, display);
+    }
+    return false;
+}
+
 function toggleDiffs(path, display) {
     var $ids = getIds(path);
 
@@ -82,52 +109,25 @@ function initDiffs() {
     $('a[name^=diff-]').each(function(index, item) {
         var id = $(item).attr('name');
 
-        if (localStorage.getItem(id) === 'hide') {
-            toggleDiff(id, 0, 'hide');
+        if (localStorage.getItem(id) === 'collapse') {
+            toggleDiff(id, 0, 'collapse');
         }
     });
 }
 
-function toggleDiff(id, duration, display) {
-    var $a = $('a[name^=' + id + ']');
-
-    duration = duration ? duration : 200;
-
-    if (display !== 'show' && display !== 'hide') {
-        display = (localStorage.getItem(id) === 'hide') ? 'show' : 'hide';
-    }
-
-    if ($a) {
-        var $span = $a.next('div[id^=diff-]');
-        var $data = $span.children('.data, .image');
-        var $bottom = $span.children('.bottom-collapse');
-
-        if (display === 'show') {
-            $data.slideDown(duration);
-            $bottom.show();
-        } else {
-            $data.slideUp(duration);
-            $bottom.hide();
-        }
-
-        return localStorage.setItem(id, display);
-    }
-    return false;
-}
-
-function clickTitle(event) {
+function clickTitle() {
     var path = $(this).attr('title');
     var id = getId(path);
 
     return toggleDiff(id);
 }
 
-function clickCollapse(event) {
+function clickCollapse() {
     var $span = $(this).prevAll('.file-header');
     var path = $span.attr('data-path');
     var id = getId(path);
 
-    return toggleDiff(id, '200', 'hide');
+    return toggleDiff(id, '200', 'collapse');
 }
 
 chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
@@ -178,10 +178,10 @@ chrome.storage.sync.get({url: '', tabSwitchingEnabled: false}, function(items) {
 
             port.onMessage.addListener(function (msg) {
                 if (msg.collapse !== undefined) {
-                    toggleDiffs(msg.collapse, 'hide');
+                    toggleDiffs(msg.collapse, 'collapse');
                 }
                 if (msg.expand !== undefined) {
-                    toggleDiffs(msg.expand, 'show');
+                    toggleDiffs(msg.expand, 'expand');
                 }
                 if (msg.goto !== undefined) {
                     getDiffSpans(msg.goto)[0].scrollIntoViewIfNeeded();

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -59,7 +59,6 @@ function toggleDiff(id, duration, display) {
 
     duration = !isNaN(duration) ? duration : 200;
 
-
     if ($.inArray(display, ['expand', 'collapse', 'toggle']) < 0) {
         if (!useLocalStorage) {
             display = 'toggle';


### PR DESCRIPTION
#### Summary

Mentionned in https://github.com/Yatser/prettypullrequests/issues/32.

#### How it works
At each click the diff state is stored in the localStorage. These states are visually restored when the plugin injects its html.

#### Notes

After using it for a while, this may be a bit heavier to process. Improvements can be brought by the use of the chrome storage.
There's too many tree traversals, it should be optimized.
There should be at least an option to restore all collapsed diffs.