### PR TITLE
Generate a pull request ID to avoid collapsing a same file across multiple PRs

### DIFF
--- a/pullrequest.js
+++ b/pullrequest.js
@@ -69,11 +69,11 @@ function getId(path) {
 function toggleDiff(id, duration, display) {
     var $a = $('a[name^=' + id + ']');
 
+    id = useLocalStorage ? getCompleteId(id) : id;
     duration = !isNaN(duration) ? duration : 200;
 
     if ($.inArray(display, ['expand', 'collapse', 'toggle']) < 0) {
         if (useLocalStorage) {
-            id = getCompleteId(id);
             display = (localStorage.getItem(id) === 'collapse') ? 'expand' : 'collapse';
         } else {
             display = 'toggle';
@@ -160,6 +160,8 @@ function clickCollapse() {
 chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled: false}, function(items) {
     if (items.url == window.location.origin ||
         "https://github.com" === window.location.origin) {
+        var $body = $('body');
+        useLocalStorage = items.saveCollapsedDiffs;
 
         var injectHtmlIfNecessary = function () {
             if (!htmlIsInjected()) {
@@ -168,8 +170,6 @@ chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled:
             }
             setTimeout(injectHtmlIfNecessary, 1000);
         };
-        var $body = $('body');
-        useLocalStorage = items.saveCollapsedDiffs;
 
         injectHtmlIfNecessary();
 

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -38,7 +38,7 @@ function getDiffSpans(path) {
 
 function getCurrentPrId() {
     var prId = $('meta[name=session-resume-id]').attr('content')
-        || '/' + document.URL.split('/').slice(3).join('/');
+        || '/' + document.URL.split('/').slice(-4).join('/');
 
     return prId + '/';
 }

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -38,12 +38,14 @@ function getDiffSpans(path) {
 }
 
 function setCurrentPrId() {
-    prId = $('meta[name=session-resume-id]').attr('content')
-        || '/' + document.URL.split('/').slice(-4).join('/');
+    prId = 'ppr' + (
+        $('meta[name=session-resume-id]').attr('content')
+        || '/' + document.URL.split('/').slice(-4).join('/')
+        ) + '/';
 }
 
 function getCompleteId(id) {
-    return prId + '/' + id;
+    return prId + id;
 }
 
 function getIds(path) {

--- a/pullrequest.js
+++ b/pullrequest.js
@@ -36,6 +36,13 @@ function getDiffSpans(path) {
     });
 }
 
+function getCurrentPrId() {
+    var prId = $('meta[name=session-resume-id]').attr('content')
+        || '/' + document.URL.split('/').slice(3).join('/');
+
+    return prId + '/';
+}
+
 function getIds(path) {
     var $spans = getDiffSpans(path).closest('[id^=diff-]');
     var $as = $spans.prev('a[name^=diff-]');
@@ -55,6 +62,7 @@ function getId(path) {
 }
 
 function toggleDiff(id, duration, display) {
+    var prId = getCurrentPrId();
     var $a = $('a[name^=' + id + ']');
 
     duration = !isNaN(duration) ? duration : 200;
@@ -63,7 +71,7 @@ function toggleDiff(id, duration, display) {
         if (!useLocalStorage) {
             display = 'toggle';
         } else {
-            display = (localStorage.getItem(id) === 'collapse') ? 'expand' : 'collapse';
+            display = (localStorage.getItem(prId + id) === 'collapse') ? 'expand' : 'collapse';
         }
     }
 
@@ -80,11 +88,11 @@ function toggleDiff(id, duration, display) {
             case 'expand':
                 $data.slideDown(duration);
                 $bottom.show();
-                return useLocalStorage ? localStorage.removeItem(id) : true;
+                return useLocalStorage ? localStorage.removeItem(prId + id) : true;
             default:
                 $data.slideUp(duration);
                 $bottom.hide();
-                return useLocalStorage ? localStorage.setItem(id, display) : true;
+                return useLocalStorage ? localStorage.setItem(prId + id, display) : true;
         }
     }
     return false;
@@ -116,10 +124,12 @@ function moveToPreviousTab($pullRequestTabs, selectedTabIndex) {
 
 function initDiffs() {
     if (useLocalStorage) {
+        var prId = getCurrentPrId();
+
         $('a[name^=diff-]').each(function(index, item) {
             var id = $(item).attr('name');
 
-            if (localStorage.getItem(id) === 'collapse') {
+            if (localStorage.getItem(prId + id) === 'collapse') {
                 toggleDiff(id, 0, 'collapse');
             }
         });


### PR DESCRIPTION
This fixes https://github.com/Yatser/prettypullrequests/issues/35.

I observed that we can use a meta named `session-resume-id` to easily have something like `/User/Repository/pull/pr-id`. I concatenate to this the `diff-id` so the key now looks like `/User/Repository/pull/pr-id/diff-id`.

In some cases, like a page showing a diff for a single commit, this useful meta is absent. I've chosen to slice by the end the `document.url` to have something like `/User/Repository/commit/commit-hash` and again concatenate to this the `diff-id`.