### PR TITLE
Fixes backtick tab switching

### DIFF
--- a/pullrequest.js
+++ b/pullrequest.js
@@ -190,8 +190,9 @@ chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled:
                   return;
               }
 
-              var $pullRequestTabs = $('.js-pull-request-tab');
-              var selectedTabIndex = $('.js-pull-request-tab.selected').index();
+              var $pullRequestTabs = $('nav.tabnav-tabs a.tabnav-tab');
+              var $selectedTab     = $('nav.tabnav-tabs a.tabnav-tab.selected');
+              var selectedTabIndex = $pullRequestTabs.index( $selectedTab );
 
               if (e.shiftKey) {
                   // Making this work like it would in other apps, where the shift


### PR DESCRIPTION
Looks like github changed the class this was looking for on the tabs.
This may be too precise with the selectors but it's working and it's a
feature I've been missing.