### PR TITLE
Fix-ups after the latest (several) rounds of GitHub updates

### DIFF
--- a/enterprise.js
+++ b/enterprise.js
@@ -7,16 +7,11 @@ var repositoryName;
 var repositoryAuthor;
 var autoCollapseExpressions;
 
-function onFilesPage() {
-    return window.location.href.indexOf('files') !== -1;
-}
-
 function htmlIsInjected() {
   return $('.pretty-pull-requests-inserted').length > 0;
 }
 
 function injectHtml() {
-  if (!onFilesPage()) return;
   $('<span class="pretty-pull-requests collapse-lines">' +
         '<label><input type="checkbox" class="js-collapse-additions" checked="yes">+</label>' +
         '<label><input type="checkbox" class="js-collapse-deletions" checked="yes">-</label>' +
@@ -152,10 +147,10 @@ function initDiffs() {
     autoCollapse();
 }
 
-function clickTitle(e) {
-    e.preventDefault();
+function clickTitle() {
     var path = $(this).attr('title') || this.innerText;
     var id = getId(path);
+    debugger;
 
     return toggleDiff(id);
 }
@@ -175,28 +170,23 @@ function autoCollapse() {
 }
 
 chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled: false, autoCollapseExpressions: []}, function(items) {
-    if (items.url === window.location.origin ||
+    if (items.url == window.location.origin ||
         "https://github.com" === window.location.origin) {
 
         autoCollapseExpressions = items.autoCollapseExpressions;
 
-        var interval = null;
         var injectHtmlIfNecessary = function () {
             if (!htmlIsInjected()) {
-                if (onFilesPage()) {
-                    collectUniquePageInfo();
-                    injectHtml();
-                    initDiffs();
-                    $body.on('click', '.user-select-contain, .js-selectable-text, .file-info .link-gray-dark', clickTitle);
-                    $body.on('click', '.bottom-collapse', clickCollapse);
-                    $body.on('click', '.js-collapse-additions', collapseAdditions);
-                    $body.on('click', '.js-collapse-deletions', collapseDeletions);
-                }
-            } else {
-                cleartInterval(interval);
+                collectUniquePageInfo();
+                injectHtml();
+                initDiffs();
+                $body.on('click', '.user-select-contain, .js-selectable-text, .file-info .link-gray-dark', clickTitle);
+                $body.on('click', '.bottom-collapse', clickCollapse);
+                $body.on('click', '.js-collapse-additions', collapseAdditions);
+                $body.on('click', '.js-collapse-deletions', collapseDeletions);
             }
+            setTimeout(injectHtmlIfNecessary, 1000);
         };
-        interval = setInterval(injectHtmlIfNecessary, 1000);
         var $body = $('body');
         useLocalStorage = items.saveCollapsedDiffs;
 

--- a/enterprise.js
+++ b/enterprise.js
@@ -7,11 +7,16 @@ var repositoryName;
 var repositoryAuthor;
 var autoCollapseExpressions;
 
+function onFilesPage() {
+    return window.location.href.indexOf('files') !== -1;
+}
+
 function htmlIsInjected() {
   return $('.pretty-pull-requests-inserted').length > 0;
 }
 
 function injectHtml() {
+  if (!onFilesPage()) return;
   $('<span class="pretty-pull-requests collapse-lines">' +
         '<label><input type="checkbox" class="js-collapse-additions" checked="yes">+</label>' +
         '<label><input type="checkbox" class="js-collapse-deletions" checked="yes">-</label>' +
@@ -147,10 +152,10 @@ function initDiffs() {
     autoCollapse();
 }
 
-function clickTitle() {
+function clickTitle(e) {
+    e.preventDefault();
     var path = $(this).attr('title') || this.innerText;
     var id = getId(path);
-    debugger;
 
     return toggleDiff(id);
 }
@@ -170,23 +175,28 @@ function autoCollapse() {
 }
 
 chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled: false, autoCollapseExpressions: []}, function(items) {
-    if (items.url == window.location.origin ||
+    if (items.url === window.location.origin ||
         "https://github.com" === window.location.origin) {
 
         autoCollapseExpressions = items.autoCollapseExpressions;
 
+        var interval = null;
         var injectHtmlIfNecessary = function () {
             if (!htmlIsInjected()) {
-                collectUniquePageInfo();
-                injectHtml();
-                initDiffs();
-                $body.on('click', '.user-select-contain, .js-selectable-text, .file-info .link-gray-dark', clickTitle);
-                $body.on('click', '.bottom-collapse', clickCollapse);
-                $body.on('click', '.js-collapse-additions', collapseAdditions);
-                $body.on('click', '.js-collapse-deletions', collapseDeletions);
+                if (onFilesPage()) {
+                    collectUniquePageInfo();
+                    injectHtml();
+                    initDiffs();
+                    $body.on('click', '.user-select-contain, .js-selectable-text, .file-info .link-gray-dark', clickTitle);
+                    $body.on('click', '.bottom-collapse', clickCollapse);
+                    $body.on('click', '.js-collapse-additions', collapseAdditions);
+                    $body.on('click', '.js-collapse-deletions', collapseDeletions);
+                }
+            } else {
+                cleartInterval(interval);
             }
-            setTimeout(injectHtmlIfNecessary, 1000);
         };
+        interval = setInterval(injectHtmlIfNecessary, 1000);
         var $body = $('body');
         useLocalStorage = items.saveCollapsedDiffs;
 

--- a/github.com.js
+++ b/github.com.js
@@ -16,7 +16,7 @@ function htmlIsInjected() {
 }
 
 function injectHtml() {
-    if (!onFilesPage()) return;
+  if (!onFilesPage()) return;
   $('<span class="pretty-pull-requests collapse-lines">' +
         '<label><input type="checkbox" class="js-collapse-additions" checked="yes">+</label>' +
         '<label><input type="checkbox" class="js-collapse-deletions" checked="yes">-</label>' +

--- a/github.com.js
+++ b/github.com.js
@@ -16,7 +16,7 @@ function htmlIsInjected() {
 }
 
 function injectHtml() {
-  if (!onFilesPage()) return;
+    if (!onFilesPage()) return;
   $('<span class="pretty-pull-requests collapse-lines">' +
         '<label><input type="checkbox" class="js-collapse-additions" checked="yes">+</label>' +
         '<label><input type="checkbox" class="js-collapse-deletions" checked="yes">-</label>' +

--- a/github.com.js
+++ b/github.com.js
@@ -169,7 +169,7 @@ function autoCollapse() {
 }
 
 chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled: false, autoCollapseExpressions: []}, function(items) {
-    if (items.url == window.location.origin ||
+    if (items.url === window.location.origin ||
         "https://github.com" === window.location.origin) {
 
         autoCollapseExpressions = items.autoCollapseExpressions;

--- a/manifest.json
+++ b/manifest.json
@@ -19,16 +19,7 @@
 
     "content_scripts": [
         {
-            "matches": ["https://github.com/*/pull/*/files",
-                        "https://github.com/*/commit*",
-                        "https://github.com/*/pulls*",
-                        "https://github.com/*/compare*",
-                        "https://github.com/*/*/pulls*",
-                        "https://github.com/*/*/pull/*",
-                        "https://github.com/*/*/pull/*/files",
-                        "https://github.com/*/*/commit*",
-                        "https://github.com/*/*/compare*"
-                        ],
+            "matches": ["https://github.com/*"],
             "js": ["jquery-1.9.1.min.js", "github.com.js"],
             "css": ["pullrequest.css"]
         }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Pretty Pull Requests (Github)",
     "description": "This extension applies various tweaks to the github pull-request code review pages.",
-    "version": "2.10.3",
+    "version": "2.11.0",
     "icons": {
         "32": "ppr-logo/32x32.png",
         "64": "ppr-logo/64x64.png",


### PR DESCRIPTION
@Yatser 

Some changes:
- Clicking on the file name would use an anchor to put the file at the top of the screen. I at least found this annoying because it didn't use to work that way.
- Now setting an interval to check if the HTML is injected rather than setting timeouts to call the function from within itself
- Only injecting HTML if we're on the files page. Partly so that we can ensure the check boxes by the file name show up, but also so that the click handlers don't get set multiple times.
- Firing up the extension on any github.com page now, simply because if you start at github.com and navigate to a PR, the extension will never load since you will not have reloaded a page.

I guess I also need to port some of this stuff to `enterprise.js` (done in #47)