### PR TITLE
Added buttons to collapse/expand source file tree

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -10,4 +10,5 @@ body {
 
 #tree {
     margin-top: 10px;
+    margin-bottom: 10px;
 }

--- a/popup.html
+++ b/popup.html
@@ -10,10 +10,14 @@
 <body>
     <div class="path-area">
         <input class="form-control" id="path" type="text" placeholder="Path (Regex)...">
-        <button class="btn btn-default btn-sm" id="collapse"><i class="glyphicon glyphicon-minus"></i></button>
-        <button class="btn btn-default btn-sm" id="expand"><i class="glyphicon glyphicon-plus"></i></button>
+        <button class="btn btn-default btn-sm" id="collapse" title="Collapse All Diffs"><i class="glyphicon glyphicon-minus"></i></button>
+        <button class="btn btn-default btn-sm" id="expand" title="Expand All Diffs"><i class="glyphicon glyphicon-plus"></i></button>
     </div>
     <div id="tree"></div>
+    <div class="path-area">
+        <button class="btn btn-default btn-sm" id="collapse-tree" title="Collapse File Tree">Collapse Tree</i></button>
+        <button class="btn btn-default btn-sm" id="expand-tree" title="Expand File Tree">Expand Tree</i></button>
+    </div>
     <script src="jquery-1.9.1.min.js"></script>
     <script src="popup.js"></script>
     <script src="jstree/jstree.min.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -14,9 +14,19 @@ function expand() {
     port.postMessage({expand: path});
 }
 
+function collapseTree() {
+    $('#tree').jstree('close_all');
+}
+
+function expandTree() {
+    $('#tree').jstree('open_all');
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     document.querySelector('#collapse').addEventListener('click', collapse);
     document.querySelector('#expand').addEventListener('click', expand);
+    document.querySelector('#collapse-tree').addEventListener('click', collapseTree);
+    document.querySelector('#expand-tree').addEventListener('click', expandTree);
 });
 
 function Node(id, parent, text, icon) {


### PR DESCRIPTION
In the spirit of [Hacktoberfest](https://hacktoberfest.digitalocean.com), I wanted to offer help contributing to `prettypullrequests`, which I use every day.

In this PR I have added buttons to the Page Action to expand/collapse the entire source tree, which I would find handy. If you think it'd be useful, can you let me know what you think? I'm happy to change the styling or layout if you like. Thanks!

Here's an example of what the first draft looks like:

<img width="269" alt="collapse-expand-buttons" src="https://user-images.githubusercontent.com/6874678/31159905-055bbffc-a892-11e7-919d-e986b0c64c76.png">