### PR TITLE
Added checkbox to toggle hiding whitespace

### DIFF
--- a/github.com.js
+++ b/github.com.js
@@ -17,6 +17,11 @@ function injectHtml() {
         '<label><input type="checkbox" class="js-collapse-deletions" checked="yes">-</label>' +
     '</span>').insertAfter('.actions, .file-actions');
 
+  $('<span class="pretty-pull-requests hide-whitespace">' +
+        '<label>Hide whitespace changes <input type="checkbox" class="js-hide-whitespace"></label>' +
+    '</span>').insertAfter('.diffbar-item.diffstat');
+  $('.js-hide-whitespace').prop('checked', isWhitespaceHidden('w'));
+
   $('<div class="pretty-pull-requests bottom-collapse">Click to Collapse</div>').insertAfter('.data.highlight.blob-wrapper');
   $('<div class="pretty-pull-requests-inserted" style="display: none"></div>').appendTo('body');
 }
@@ -36,6 +41,29 @@ function collapseDeletions() {
         $(this).closest('[id^=diff-]').find('.gd').slideToggle();
     }
 }
+
+// Whitespace is hidden if query parameter w=1 is set
+function isWhitespaceHidden() {
+    var regex = new RegExp("[?;&]w(=([^&;#]*)|&|;|#|$)"),
+        results = regex.exec(window.location.search);
+    return results && results[2] && results[2] === '1';
+}
+
+function toggleWhitespace() {
+    window.location.search = setQueryParam(window.location.search, 'w', (isWhitespaceHidden() ? '0' : '1'));
+}
+
+var setQueryParam = function(search, key, val){
+    var newParam = key + '=' + val;
+    if (search.length === 0) {
+        return '?' + newParam;
+    }
+    var searchNew = search.replace(new RegExp('([?;&])' + key + '[^;&]*'), '$1' + newParam);
+    if (searchNew === search) {
+        searchNew += '&' + newParam;
+    }
+    return searchNew;
+};
 
 function getDiffSpans(path) {
     return $('.file-info .link-gray-dark').filter(function () {
@@ -177,6 +205,7 @@ chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled:
                 $body.on('click', '.bottom-collapse', clickCollapse);
                 $body.on('click', '.js-collapse-additions', collapseAdditions);
                 $body.on('click', '.js-collapse-deletions', collapseDeletions);
+                $body.on('click', '.js-hide-whitespace', toggleWhitespace);
             }
             setTimeout(injectHtmlIfNecessary, 1000);
         };

--- a/github.com.js
+++ b/github.com.js
@@ -20,7 +20,7 @@ function injectHtml() {
   $('<span class="pretty-pull-requests hide-whitespace">' +
         '<label>Hide whitespace changes <input type="checkbox" class="js-hide-whitespace"></label>' +
     '</span>').insertAfter('.diffbar-item.diffstat');
-  $('.js-hide-whitespace').prop('checked', isWhitespaceHidden('w'));
+  $('.js-hide-whitespace').prop('checked', isWhitespaceHidden());
 
   $('<div class="pretty-pull-requests bottom-collapse">Click to Collapse</div>').insertAfter('.data.highlight.blob-wrapper');
   $('<div class="pretty-pull-requests-inserted" style="display: none"></div>').appendTo('body');

--- a/pullrequest.css
+++ b/pullrequest.css
@@ -12,6 +12,14 @@
     margin-left: 10px;
 }
 
+.hide-whitespace label {
+    display: block;
+    font-size: 13px;
+    font-weight: normal;
+    line-height: 18px;
+    margin-left: 10px;
+}
+
 .js-selectable-text,
 .user-select-contain {
     cursor: pointer;


### PR DESCRIPTION
Hello @Yatser, I added another feature to `prettypullrequests`; I hope you don't mind.

Frequently I add `?w=1` to pull request URL's to view them with whitespace-only changes hidden. I thought I might add a simple checkbox to ppr to save a little typing each time, and expose this feature to a wider audience. Let me know what you think. Thanks!

I placed the checkbox at the top of the files page, by the other metadata about all files, like this:

<img width="627" alt="screen shot 2017-10-15 at 10 09 21 am" src="https://user-images.githubusercontent.com/6874678/31586059-6f6b6d86-b191-11e7-96e4-1d9048c948e1.png">
