### PR TITLE
Change HTML injection to wait until "Files changed" tab is open

### DIFF
--- a/github.com.js
+++ b/github.com.js
@@ -7,8 +7,8 @@ var repositoryName;
 var repositoryAuthor;
 var autoCollapseExpressions;
 
-function htmlIsInjected() {
-  return $('.pretty-pull-requests-inserted').length > 0;
+function htmlShouldBeInjected() {
+  return $('a[href$="/files"].tabnav-tab.selected').length > 0 && $('.pretty-pull-requests-inserted').length <= 0;
 }
 
 function injectHtml() {
@@ -197,7 +197,7 @@ chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled:
         autoCollapseExpressions = items.autoCollapseExpressions;
 
         var injectHtmlIfNecessary = function () {
-            if (!htmlIsInjected()) {
+            if (htmlShouldBeInjected()) {
                 collectUniquePageInfo();
                 injectHtml();
                 initDiffs();


### PR DESCRIPTION
Hi @Yatser, me again. I thought of another enhancement idea while tinkering with another extension.

I noticed that when you open a Pull Request page and it starts on the "Conversation" tab, and you tab over to "Files Changed" by clicking or hitting backtick, the prettypullrequests widgets are not present. I'm guessing at some point GitHub switched that navigation to use ajax/pjax, and as a result you need to reload the page to get the prettypullrequests UI to appear.

I fixed this by changing the HTML injection to effectively wait until the "Files Changed" tab is active. It seems to work in my tests. See what you think. Thanks again!