### PR TITLE
Handle long file names that get truncated by github

### DIFF
--- a/github.com.js
+++ b/github.com.js
@@ -67,7 +67,7 @@ var setQueryParam = function(search, key, val){
 
 function getDiffSpans(path) {
     return $('.file-info .link-gray-dark').filter(function () {
-        return this.innerHTML.trim().match(path);
+        return this.title.trim().match(path);
     });
 }
 
@@ -255,7 +255,7 @@ chrome.storage.sync.get({url: '', saveCollapsedDiffs: true, tabSwitchingEnabled:
         chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
             if (request.getPaths) {
                 var paths = $.map($('.file-info .link-gray-dark'), function (item) {
-                    return $.trim(item.innerHTML);
+                    return $.trim(item.title);
                 });
                 if (paths.length > 0) {
                     sendResponse({paths: paths});

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Pretty Pull Requests (Github)",
     "description": "This extension applies various tweaks to the github pull-request code review pages.",
-    "version": "2.10.4",
+    "version": "2.11.1",
     "icons": {
         "32": "ppr-logo/32x32.png",
         "64": "ppr-logo/64x64.png",


### PR DESCRIPTION
When file paths are long, github truncates the text above the diff (the
innerHTML) but leave the title in-tact.

This commit changes Pretty PRs to consider the title instead of the
innerHTML when identifying common paths.

@byates-va @Yatser

### Before
![screen shot 2018-01-29 at 4 20 08 pm](https://user-images.githubusercontent.com/8963131/35537600-69df7f1a-0510-11e8-8102-636858677223.png)

### After
![screen shot 2018-01-29 at 4 19 44 pm](https://user-images.githubusercontent.com/8963131/35537604-6ef53576-0510-11e8-9cfa-461d3f0248b9.png)

![image](https://user-images.githubusercontent.com/8963131/35537633-8bd01f08-0510-11e8-8fa8-0bf7e9f28163.png)
