### PR TITLE
Fix diff collapsing

### DIFF
--- a/github.com.js
+++ b/github.com.js
@@ -73,12 +73,8 @@ function getDiffSpans(path) {
 
 function getIds(path) {
     var $spans = getDiffSpans(path).closest('[id^=diff-]');
-    var $as = $spans.prev('a[name^=diff-]');
-    var $ids = $as.map(function(index, a) {
-        return $(a).attr('name');
-    });
-
-    return $ids;
+    const ids = $spans.map((index, a) => a.id);
+    return ids;
 }
 
 function getId(path) {
@@ -103,7 +99,7 @@ function collectUniquePageInfo() {
 }
 
 function toggleDiff(id, duration, display) {
-    var $a = $('a[name^=' + id + ']');
+    var $a = $(`#${id}`);
     duration = !isNaN(duration) ? duration : 200;
 
     if ($.inArray(display, ['expand', 'collapse', 'toggle']) < 0) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Pretty Pull Requests (Github)",
     "description": "This extension applies various tweaks to the github pull-request code review pages.",
-    "version": "2.11.1",
+    "version": "2.11.2",
     "icons": {
         "32": "ppr-logo/32x32.png",
         "64": "ppr-logo/64x64.png",


### PR DESCRIPTION
Collapsing diffs from the extension menu stopped working recently.  This brings it back.
![simplescreenrecorder-2020-05-19_10 08 11](https://user-images.githubusercontent.com/8963131/82350573-c36db300-99b8-11ea-9b7c-70eed33e16ad.gif)
